### PR TITLE
#19: Fix URL name unique validation check

### DIFF
--- a/legaltext/admin.py
+++ b/legaltext/admin.py
@@ -27,10 +27,24 @@ class LegalTextVersionAdminForm(forms.ModelForm):
         super(LegalTextVersionAdminForm, self).__init__(*args, **kwargs)
 
 
+class LegalTextAdminForm(forms.ModelForm):
+
+    class Meta:
+        model = LegalText
+        fields = '__all__'
+
+    def clean_url_name(self):
+        url_name = self.cleaned_data['url_name']
+        if not url_name:
+            return None
+        return url_name
+
+
 @admin.register(LegalText)
 class LegalTextAdmin(admin.ModelAdmin):
     list_display = ('name', 'current_version_link', 'add_new_version_link')
     search_fields = ('name',)
+    form = LegalTextAdminForm
 
     def get_prepopulated_fields(self, request, obj=None):
         return {'slug': ('name',)} if obj is None else {}

--- a/testing/tests/test_admin.py
+++ b/testing/tests/test_admin.py
@@ -39,6 +39,29 @@ class TestLegalTextAdmin:
         html = self.modeladmin.add_new_version_link(legal_text)
         assert '/legaltextversion/add/?legaltext={0}'.format(legal_text.pk) in html
 
+    def test_url_name_is_unique(self, admin_client):
+        url = reverse('admin:legaltext_legaltext_add')
+        data = {'name': 'First', 'slug': 'first', 'url_name': 'first'}
+        duplicated_data = {'name': 'Second', 'slug': 'second', 'url_name': 'first'}
+
+        admin_client.post(url, data)
+        response = admin_client.post(url, duplicated_data)
+
+        assert response.status_code == 200
+        assert LegalText.objects.count() == 1
+        assert len(response.context['errors']) == 1
+
+    def test_url_name_can_be_blank(self, admin_client):
+        url = reverse('admin:legaltext_legaltext_add')
+        data = {'name': 'First', 'slug': 'first', 'url_name': ''}
+        other_data = {'name': 'Second', 'slug': 'second', 'url_name': ''}
+
+        admin_client.post(url, data)
+        response = admin_client.post(url, other_data)
+
+        assert response.status_code == 302
+        assert LegalText.objects.count() == 2
+
 
 @pytest.mark.django_db
 class TestLegalTextCheckboxInline:

--- a/testing/tests/test_models.py
+++ b/testing/tests/test_models.py
@@ -78,6 +78,20 @@ class TestLegalText:
         assert version.content == 'Test content 2'
         assert version.pk == version_present.pk
 
+    def test_url_name_is_unique(self):
+        LegalTextFactory.create(url_name='foo-bar-test')
+        with pytest.raises(IntegrityError):
+            LegalTextFactory.create(url_name='foo-bar-test')
+
+    def test_url_name_is_unique_with_blank(self):
+        LegalTextFactory.create(url_name='')
+        with pytest.raises(IntegrityError):
+            LegalTextFactory.create(url_name='')
+
+    def test_url_name_is_not_unique_with_none(self):
+        LegalTextFactory.create(url_name=None)
+        LegalTextFactory.create(url_name=None)
+
 
 @pytest.mark.django_db
 class TestLegalTextVersion:


### PR DESCRIPTION
Hi Andreas,

LegalText has two fields for specifying url: slug (obligatory) and url_name (optional). Both fields are SlugFields and have unique constraint set to True. This way we can have internal slug in Englisch and German url_name which will be used in the url. However, currently admin form validation complains if there are two LegalTexts without url_name as it violates unique constraint.

This branch adda LegalTextAdminForm which sets url_name to None if it is not given in clean_url_name method.

Alternatively I could do the entire validation in clean_url_name and take out the unique constraint.

I prefer the first solution as the url_name should be unique and this way it is secured on the db level.

LG,
Magdalena