### PR TITLE
Update packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ with open(os.path.join(os.path.dirname(__file__), 'README.rst')) as readme:
 
 
 install_requires = [
-    'Django>=1.9,<1.11.3',
+    'Django>=1.11.23,<2.0',
     'django-floppyforms>=1.7.0',
     'django-markymark>=1.0.0',
 ]
@@ -48,14 +48,14 @@ install_requires = [
 
 test_requires = [
     'py>=1.4.26',
-    'pyflakes==1.1.0',
+    'pyflakes==2.1.1',
     'pytest>=3.0.7',
     'pytest-cache>=1.0',
     'pytest-cov>=2.1.0',
-    'pytest-flakes>=1.0.1',
+    'pytest-flakes>=4.0.0',
     'pytest-isort==0.1.0',
     'pytest-pep8>=1.0.6',
-    'pytest-django==3.1.2',
+    'pytest-django==3.5.0',
     'fake-factory==0.7.4',
     'factory-boy>=2.7.0,<2.8',
     'freezegun>=0.3.7,<0.4',
@@ -64,6 +64,7 @@ test_requires = [
     'pep8>=1.6.2',
     'tox',
     'tox-pyenv',
+    'isort==4.2.5'
 ]
 
 setup(

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist = True
-envlist={py27,py34,py35}-django{19,110,111}
+envlist={py27,py34,py35}-django{19,110,111}-marky
 
 [tox:travis]
 2.7 = py27
@@ -14,6 +14,8 @@ deps =
 	.[tests]
 	django19: Django>=1.9,<1.10
 	django110: Django>=1.10,<1.11
-	django111: Django>=1.11,<1.12
+	django111: Django>=1.11.23,<1.12
+	marky: django-markymark==1.0.0
+
 commands =
 	py.test --cov


### PR DESCRIPTION
Remove obsolete django from requirements in setup.
Still test with django 1.9 1n 1.10 as we have it in some projects.